### PR TITLE
update nix-shell for flakes

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,9 @@
 { system ? builtins.currentSystem
-, nixpkgs ? import ./nix { inherit system; }
+, nixpkgs ? import (import ./flake.lock.nix).nixpkgs {
+    inherit system;
+    configuration = { };
+    overlays = [ ];
+  }
 }:
 nixpkgs.mkShell {
   nativeBuildInputs = [ nixpkgs.ruby ];


### PR DESCRIPTION
copies the changes from 2b4b2e31d1b180d924a88100ff8967eced932903

should fix the the failing cron.

Probably want to disable hercules for this repo as well? 

https://hercules-ci.com/github/nix-community/nixpkgs-terraform-providers-bin