### PR TITLE
ci: add nixpkgs-unstable for nix-shell

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v17
+        with:
+          nix_path: nixpkgs=channel:nixpkgs-unstable
       - uses: cachix/cachix-action@v10
         with:
           name: nix-community

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v17
+        with:
+          nix_path: nixpkgs=channel:nixpkgs-unstable
       - uses: cachix/cachix-action@v10
         with:
           name: nix-community


### PR DESCRIPTION
needs to find bash in NIX_PATH