### PR TITLE
ci: remove cachix cache

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -11,10 +11,6 @@ jobs:
       - uses: cachix/install-nix-action@v17
         with:
           nix_path: nixpkgs=channel:nixpkgs-unstable
-      - uses: cachix/cachix-action@v10
-        with:
-          name: nix-community
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         # Update all the providers
       - run: ./update.rb
         # Check that everything is still working

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -18,8 +18,4 @@ jobs:
       - uses: cachix/install-nix-action@v17
         with:
           nix_path: nixpkgs=channel:nixpkgs-unstable
-      - uses: cachix/cachix-action@v10
-        with:
-          name: nix-community
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: ./ci.sh


### PR DESCRIPTION
The cache hasn't been working since it moved to `nix-community` but as we're only packaging binaries we probably don't need it anyway.