### PR TITLE
expose metadata provider-source-address

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -28,6 +28,7 @@ let
     }:
     let
       inherit (nixpkgs.go) GOARCH GOOS;
+      provider-source-address = "${registry}/${owner}/${repo}";
     in
     stdenv.mkDerivation {
       pname = "terraform-provider-${repo}";
@@ -42,10 +43,14 @@ let
 
       # The upstream terraform wrapper assumes the provider filename here.
       installPhase = ''
-        dir=$out/libexec/terraform-providers/${registry}/${owner}/${repo}/${version}/${GOOS}_${GOARCH}
+        dir=$out/libexec/terraform-providers/${provider-source-address}/${version}/${GOOS}_${GOARCH}
         mkdir -p "$dir"
         mv terraform-* "$dir/"
       '';
+
+      passthru = {
+        inherit provider-source-address;
+      };
     };
 
   providers = lib.mapAttrs


### PR DESCRIPTION
This ensures you can write scripts that generate required_providers blocks and similar. This information is needed to achieve this and is exposed by the packages produced by nixpkgs.

For example I use this here:
https://github.com/terlar/nix-terraform/blob/main/pkgs-lib/default.nix#L25