### PR TITLE
Make mkTerraformProvider overridable

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -18,7 +18,7 @@ let
     in
     nixpkgs.fetchurl src;
 
-  mkTerraformProvider =
+  mkTerraformProvider = lib.makeOverridable (
     { owner
     , repo
     , version
@@ -51,7 +51,7 @@ let
       passthru = {
         inherit provider-source-address;
       };
-    };
+    });
 
   providers = lib.mapAttrs
     (name: type:


### PR DESCRIPTION
I "need" this to override registry to registry.opentofu.org for some providers. I encountered something weird where setting 
```terraform
terraform {
  required_providers {
    random = {
      source = "registry.terraform.io/hashicorp/random"
    }
}
```
still would try to look up random in registry.opentofu.org.... So I had to make random available there when setting TF_PLUGIN_DIR and stuff :)
