### PR TITLE
Fix evaluation with OpenTofu in nixpkgs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -25,6 +25,7 @@ let
     , archSrc
     , # TODO: pass this down
       registry ? "registry.terraform.io"
+    , ...
     }:
     let
       inherit (nixpkgs.go) GOARCH GOOS;


### PR DESCRIPTION
Allow extra arguments to mkTerraformProvider since OpenTofus withPlugins function overrides provider-source-address to set provider registry to registry.opentofu.org rather than registry.terrraform.io.

Not sure exactly how and when it worked before. This silently ignores any extra arguments.

Fixes this eval error:
```
error:
       … while evaluating 'strict' to select 'drvPath' on it
         at /builtin/derivation.nix:1:552:
       … while calling the 'derivationStrict' builtin
         at /builtin/derivation.nix:1:208:
       (stack trace truncated; use '--show-trace' to show the full trace)

       error: function 'anonymous lambda' called with unexpected argument 'provider-source-address'
       at /nix/store/3qfsm6xi1p7gghms7kjfdqzffxg41d5w-source/default.nix:22:5:
           21|   mkTerraformProvider = lib.makeOverridable (
           22|     { owner
             |     ^
           23|     , repo
```

TODO: Support provider-source-address so this repo doesn't require you to override registry manually. (Or improve docs regarding the differenences)