### PR TITLE
ci: cron yaml will not run on ubuntu 20.04, change to latest

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -5,7 +5,7 @@ on:
   - cron: '0 0 * * *'  # every day at midnight
 jobs:
   update:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v30


### PR DESCRIPTION
the workflow is immediately canceled when running with 20.04 ubuntu. change to latest and it runs. 

tested on my fork with just that change and it worked great