### PR TITLE
feat: add infisical provider

### DIFF
--- a/providers/infisical/infisical/default.json
+++ b/providers/infisical/infisical/default.json
@@ -1,0 +1,27 @@
+{
+  "archSrc": {
+    "aarch64-darwin": {
+      "sha256": "914ca13cbf6bc59cc0633be95db220bdfe73354ecf29f2452202d7b034d7b295",
+      "url": "https://github.com/Infisical/terraform-provider-infisical/releases/download/v0.16.15/terraform-provider-infisical_0.16.15_darwin_arm64.zip"
+    },
+    "aarch64-linux": {
+      "sha256": "1c505f12e3dfa504f383d47e6cb05d1c2491540883ea99234f3b72f972dbac9e",
+      "url": "https://github.com/Infisical/terraform-provider-infisical/releases/download/v0.16.15/terraform-provider-infisical_0.16.15_linux_arm64.zip"
+    },
+    "i686-linux": {
+      "sha256": "e61baabce0e762603699eaf8fd411215c941dea1675ca5a2734942d21249c479",
+      "url": "https://github.com/Infisical/terraform-provider-infisical/releases/download/v0.16.15/terraform-provider-infisical_0.16.15_linux_386.zip"
+    },
+    "x86_64-darwin": {
+      "sha256": "abb8a3f6f46779339b3ade55f8705fd171eb469cd923b6144efc42f6a5665305",
+      "url": "https://github.com/Infisical/terraform-provider-infisical/releases/download/v0.16.15/terraform-provider-infisical_0.16.15_darwin_amd64.zip"
+    },
+    "x86_64-linux": {
+      "sha256": "b311ab4a8ffa7da2fe8693c306130c6f0ac537f0ad72cf860b2dce84e45bab38",
+      "url": "https://github.com/Infisical/terraform-provider-infisical/releases/download/v0.16.15/terraform-provider-infisical_0.16.15_linux_amd64.zip"
+    }
+  },
+  "owner": "infisical",
+  "repo": "infisical",
+  "version": "0.16.15"
+}


### PR DESCRIPTION
Init [infisical/infisical](https://registry.terraform.io/providers/Infisical/infisical/latest) at v0.16.15

Generated via `./update.rb infisical/infisical`